### PR TITLE
Correct library.properties url field value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=David Lyckelid <david@goodsolutions.se>
 sentence=Arduino library for Semtech KX023-1025 IMU
 paragraph=Supports SPI and I2C communications
 category=Sensors
-url=http://https://github.com/dlyckelid/KX023-1025-IMU/
+url=https://github.com/dlyckelid/KX023-1025-IMU/
 architectures=*
 includes=KX0231025IMU.h


### PR DESCRIPTION
The previous redundant "https://" on the URL in library.properties caused the "More info" link to not load.

In order to resolve this issue in the Arduino Library Manager index, as mentioned at https://github.com/arduino/Arduino/issues/11293#issuecomment-790107152, the following must be done;
1. Merge this pull request.
1. Update the library.properties `version` value.
1. Create a new  [release](https://help.github.com/articles/creating-releases/) or [tag](https://git-scm.com/docs/git-tag) that matches the `version` value in library.properties.

After that, it will take some hours for the library Manager indexer and the CDN cache propagation to occur before the fix shows up in Library Manager, but everything will happen automatically.