### PR TITLE
update version number to latest release

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=KX0231025IMU
-version=1.0.1
+version=1.0.2
 author=David Lyckelid <david@goodsolutions.se>
 maintainer=David Lyckelid <david@goodsolutions.se>
 sentence=Arduino library for Semtech KX023-1025 IMU


### PR DESCRIPTION
This should allow the arduino library manager to fetch & install your latest release.
This is the current Library Manager indexer log:

> 2022/06/15 12:19:50 Scraping https://github.com/dlyckelid/KX023-1025-IMU.git
2022/06/15 12:19:51 Checking out tag: 1.0.0
2022/06/15 12:19:51 Release KX0231025IMU:1.0.0 already loaded, skipping
2022/06/15 12:19:51 Checking out tag: 1.0.1
2022/06/15 12:19:51 Release KX0231025IMU:1.0.1 already loaded, skipping
2022/06/15 12:19:51 Checking out tag: 1.0.2
2022/06/15 12:19:51 Release KX0231025IMU:1.0.1 already loaded, skipping
